### PR TITLE
 feat: 근태 및 연차 관리 기능 개선

### DIFF
--- a/attendance-service/src/main/java/com/playdata/attendanceservice/attendance/controller/AttendanceController.java
+++ b/attendance-service/src/main/java/com/playdata/attendanceservice/attendance/controller/AttendanceController.java
@@ -1,6 +1,7 @@
 package com.playdata.attendanceservice.attendance.controller;
 
 import com.playdata.attendanceservice.attendance.dto.AttendanceResDto;
+import com.playdata.attendanceservice.attendance.dto.WorkTimeDto;
 import com.playdata.attendanceservice.attendance.entity.Attendance;
 import com.playdata.attendanceservice.attendance.service.AttendanceService;
 import com.playdata.attendanceservice.client.VacationServiceClient; // 추가
@@ -122,6 +123,23 @@ public class AttendanceController {
             return buildErrorResponse(HttpStatus.BAD_REQUEST, e.getMessage());
         } catch (Exception e) {
             return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "복귀 기록 중 오류 발생");
+        }
+    }
+
+    /**
+     * 사용자의 남은 근무 시간을 조회하는 API 엔드포인트입니다.
+     *
+     * @param userInfo 인증된 사용자의 정보 (userId 획득용)
+     * @return 남은 근무 시간 문자열 또는 오류에 대한 응답 (CommonResDto)
+     */
+    @GetMapping("/remaining-work-time")
+    public ResponseEntity<CommonResDto<?>> getRemainingWorkTime(@AuthenticationPrincipal TokenUserInfo userInfo) {
+        try {
+            WorkTimeDto remainingTime = attendanceService.getRemainingWorkTime(userInfo.getEmployeeNo());
+            return buildSuccessResponse(remainingTime, "남은 근무 시간 조회 성공");
+        } catch (Exception e) {
+            log.error("남은 근무 시간 조회 중 오류 발생: {}", e.getMessage(), e);
+            return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "남은 근무 시간 조회 중 오류 발생");
         }
     }
 

--- a/attendance-service/src/main/java/com/playdata/attendanceservice/attendance/controller/AttendanceController.java
+++ b/attendance-service/src/main/java/com/playdata/attendanceservice/attendance/controller/AttendanceController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 
 
 import java.util.List;
+import java.util.Optional; // 추가
 
 @RestController
 @RequestMapping("/attendance")
@@ -140,6 +141,28 @@ public class AttendanceController {
         } catch (Exception e) {
             log.error("남은 근무 시간 조회 중 오류 발생: {}", e.getMessage(), e);
             return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "남은 근무 시간 조회 중 오류 발생");
+        }
+    }
+
+    /**
+     * 특정 사용자의 오늘 출근 기록을 조회하는 API 엔드포인트입니다.
+     * 로그인 후 또는 페이지 로드 시 현재 사용자의 출퇴근, 외출/복귀 시간을 프론트엔드에 제공합니다.
+     *
+     * @param userInfo 인증된 사용자의 정보 (userId 획득용)
+     * @return 오늘 출근 기록이 있다면 AttendanceResDto, 없다면 null을 포함한 CommonResDto
+     */
+    @GetMapping("/today")
+    public ResponseEntity<CommonResDto<?>> getTodayAttendance(@AuthenticationPrincipal TokenUserInfo userInfo) {
+        try {
+            Optional<AttendanceResDto> todayAttendance = attendanceService.getTodayAttendance(userInfo.getEmployeeNo());
+            if (todayAttendance.isPresent()) {
+                return buildSuccessResponse(todayAttendance.get(), "오늘 근태 기록 조회 성공");
+            } else {
+                return buildSuccessResponse(null, "오늘 근태 기록 없음"); // 기록이 없는 경우 null 반환
+            }
+        } catch (Exception e) {
+            log.error("오늘 근태 기록 조회 중 오류 발생: {}", e.getMessage(), e);
+            return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "오늘 근태 기록 조회 중 오류 발생");
         }
     }
 

--- a/attendance-service/src/main/java/com/playdata/attendanceservice/attendance/dto/WorkTimeDto.java
+++ b/attendance-service/src/main/java/com/playdata/attendanceservice/attendance/dto/WorkTimeDto.java
@@ -1,0 +1,17 @@
+package com.playdata.attendanceservice.attendance.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class WorkTimeDto {
+    private String remainingHours;
+    private String workedHours;
+
+    public WorkTimeDto(String remainingHours, String workedHours) {
+        this.remainingHours = remainingHours;
+        this.workedHours = workedHours;
+    }
+
+}

--- a/attendance-service/src/main/java/com/playdata/attendanceservice/common/auth/JwtAuthFilter.java
+++ b/attendance-service/src/main/java/com/playdata/attendanceservice/common/auth/JwtAuthFilter.java
@@ -1,6 +1,8 @@
 package com.playdata.attendanceservice.common.auth;
 
 
+
+import com.playdata.attendanceservice.common.auth.TokenUserInfo;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -57,7 +59,6 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
     }
 }
-
 
 
 

--- a/attendance-service/src/main/java/com/playdata/attendanceservice/common/auth/JwtTokenProvider.java
+++ b/attendance-service/src/main/java/com/playdata/attendanceservice/common/auth/JwtTokenProvider.java
@@ -7,23 +7,26 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import lombok.extern.slf4j.Slf4j;
+import java.time.Duration;
 import java.util.Date;
 
 
 @Component
+@Slf4j
 public class JwtTokenProvider {
 
     @Value("${jwt.secretKey}")
     private String secretKey;
 
     @Value("${jwt.expiration}")
-    private int expiration;
+    private Duration expiration;
 
     @Value("${jwt.secretKeyRt}")
     private String secretKeyRt;
 
     @Value("${jwt.expirationRt}")
-    private int expirationRt;
+    private Duration expirationRt;
 
 
     public String createToken(String email, String hrRole, Long employeeNo){
@@ -32,10 +35,11 @@ public class JwtTokenProvider {
         claims.put("employeeNo", employeeNo);
         Date now = new Date();
 
+        log.info("Access Token Expiration (millis): {}", expiration.toMillis()); // 추가
         return Jwts.builder()
                 .setClaims(claims)
                 .setIssuedAt(now)
-                .setExpiration(new Date(now.getTime() + expiration * 100 * 10000))
+                .setExpiration(new Date(now.getTime() + expiration.toMillis()))
                 .signWith(SignatureAlgorithm.HS256, secretKey)
                 .compact();
     }
@@ -46,10 +50,11 @@ public class JwtTokenProvider {
         claims.put("employeeNo", employeeNo);
         Date now = new Date();
 
+        log.info("Refresh Token Expiration (millis): {}", expirationRt.toMillis()); // 추가
         return Jwts.builder()
                 .setClaims(claims)
                 .setIssuedAt(now)
-                .setExpiration(new Date(now.getTime() + expirationRt * 60 * 1000))
+                .setExpiration(new Date(now.getTime() + expirationRt.toMillis()))
                 .signWith(SignatureAlgorithm.HS256, secretKeyRt)
                 .compact();
     }
@@ -84,9 +89,6 @@ public class JwtTokenProvider {
                 .build();
     }
 }
-
-
-
 
 
 

--- a/attendance-service/src/main/java/com/playdata/attendanceservice/common/auth/TokenUserInfo.java
+++ b/attendance-service/src/main/java/com/playdata/attendanceservice/common/auth/TokenUserInfo.java
@@ -2,6 +2,12 @@ package com.playdata.attendanceservice.common.auth;
 
 
 import lombok.*;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails; // UserDetails 임포트
+
+import java.util.Collection;
+import java.util.Collections;
 
 @Setter
 @Getter
@@ -9,12 +15,45 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class TokenUserInfo {
+public class TokenUserInfo implements UserDetails { // UserDetails 인터페이스 구현
 
     private String email;
     private String hrRole;
     private Long employeeNo;
 
+    // UserDetails 인터페이스 구현 메소드
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + hrRole));
+    }
 
+    @Override
+    public String getPassword() {
+        return null; // 비밀번호는 토큰에 포함되지 않으므로 null 반환
+    }
 
+    @Override
+    public String getUsername() {
+        return email; // 사용자 이름으로 email 사용
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
 }

--- a/vacation-service/src/main/java/com/playdata/vacationservice/VacationServiceApplication.java
+++ b/vacation-service/src/main/java/com/playdata/vacationservice/VacationServiceApplication.java
@@ -5,6 +5,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients; // 추가
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing; // 추가
 import org.springframework.scheduling.annotation.EnableScheduling; // 추가 (스케줄러가 있다면)
+import com.playdata.vacationservice.vacation.service.VacationService; // VacationService 임포트
+import org.springframework.boot.CommandLineRunner; // CommandLineRunner 임포트
+import org.springframework.context.annotation.Bean; // @Bean 임포트
 
 @SpringBootApplication
 @EnableFeignClients // Feign 클라이언트를 활성화합니다。
@@ -14,6 +17,26 @@ public class VacationServiceApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(VacationServiceApplication.class, args);
+    }
+
+    // 개발 환경에서 테스트를 위해 더미 연차 데이터를 추가하는 CommandLineRunner
+    @Bean
+    public CommandLineRunner initData(VacationService vacationService) {
+        return args -> {
+            // 테스트할 사용자 ID 목록
+            Long[] testUserIds = {1L, 2L, 3L, 4L, 5L}; // 예시: 1번부터 5번까지의 사용자 ID
+            int initialVacationDays = 15; // 부여할 연차 일수
+
+            for (Long userId : testUserIds) {
+                try {
+                    vacationService.grantAnnualLeave(userId, initialVacationDays);
+                    System.out.println("테스트 사용자(ID: " + userId + ")에게 연차 " + initialVacationDays + "일이 성공적으로 부여되었습니다.");
+                } catch (Exception e) {
+                    System.err.println("테스트 사용자(ID: " + userId + ") 연차 부여 중 오류 발생: " + e.getMessage());
+                    // 이미 연차가 부여되어 있을 경우 예외가 발생할 수 있으므로, 무시하거나 로그만 남깁니다.
+                }
+            }
+        };
     }
 
 }

--- a/vacation-service/src/main/java/com/playdata/vacationservice/client/ApprovalServiceClient.java
+++ b/vacation-service/src/main/java/com/playdata/vacationservice/client/ApprovalServiceClient.java
@@ -17,6 +17,6 @@
          *
          * @param requestDto 결재 생성에 필요한 정보
          */
-        @PostMapping("/api/v1/approvals")
+        @PostMapping("/approvals")
         void createApproval(@RequestBody ApprovalRequestDto requestDto);
     }

--- a/vacation-service/src/main/java/com/playdata/vacationservice/common/auth/JwtTokenProvider.java
+++ b/vacation-service/src/main/java/com/playdata/vacationservice/common/auth/JwtTokenProvider.java
@@ -1,92 +1,121 @@
 package com.playdata.vacationservice.common.auth;
 
 
+import com.playdata.vacationservice.common.auth.TokenUserInfo;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import lombok.extern.slf4j.Slf4j;
+import java.time.Duration;
 import java.util.Date;
 
 
 @Component
+@Slf4j
 public class JwtTokenProvider {
 
     @Value("${jwt.secretKey}")
     private String secretKey;
 
     @Value("${jwt.expiration}")
-    private int expiration;
+    private Duration expiration;
 
     @Value("${jwt.secretKeyRt}")
     private String secretKeyRt;
 
     @Value("${jwt.expirationRt}")
-    private int expirationRt;
+    private Duration expirationRt;
 
 
-    public String createToken(String email, String hrRole, Long employeeNo){
+    public String createToken(String email, String hrRole, Long employeeNo) {
         Claims claims = Jwts.claims().setSubject(email);
         claims.put("role", hrRole);
         claims.put("employeeNo", employeeNo);
         Date now = new Date();
 
+        log.info("Access Token Expiration (millis): {}", expiration.toMillis()); // 추가
         return Jwts.builder()
                 .setClaims(claims)
                 .setIssuedAt(now)
-                .setExpiration(new Date(now.getTime() + expiration * 100 * 10000))
+                .setExpiration(new Date(now.getTime() + expiration.toMillis()))
                 .signWith(SignatureAlgorithm.HS256, secretKey)
                 .compact();
     }
 
-    public String createRefreshToken(String email, String hrRole, Long employeeNo){
+    public String createRefreshToken(String email, String hrRole, Long employeeNo) {
         Claims claims = Jwts.claims().setSubject(email);
         claims.put("role", hrRole);
         claims.put("employeeNo", employeeNo);
         Date now = new Date();
 
+        log.info("Refresh Token Expiration (millis): {}", expirationRt.toMillis()); // 추가
         return Jwts.builder()
                 .setClaims(claims)
                 .setIssuedAt(now)
-                .setExpiration(new Date(now.getTime() + expirationRt * 60 * 1000))
+                .setExpiration(new Date(now.getTime() + expirationRt.toMillis()))
                 .signWith(SignatureAlgorithm.HS256, secretKeyRt)
                 .compact();
     }
 
-    public TokenUserInfo validateAndGetTokenUserInfo(String token)
-            throws Exception {
-        Claims claims = Jwts.parserBuilder()
-                .setSigningKey(secretKey)
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
+    public TokenUserInfo validateAndGetTokenUserInfo(String token) throws Exception {
+        log.info("JwtTokenProvider: Validating token - {}", token); // 로그 추가
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+            log.info("JwtTokenProvider: Token claims - Subject: {}, Role: {}, EmployeeNo: {}", // 로그 추가
+                    claims.getSubject(), claims.get("role", String.class), claims.get("employeeNo", Long.class));
 
-        return TokenUserInfo.builder()
-                .email(claims.getSubject())
-                .hrRole(claims.get("role", String.class))
-                .employeeNo(claims.get("employeeNo", Long.class))
-                .build();
+            return TokenUserInfo.builder()
+                    .email(claims.getSubject())
+                    .hrRole(claims.get("role", String.class))
+                    .employeeNo(claims.get("employeeNo", Long.class))
+                    .build();
+        } catch (io.jsonwebtoken.ExpiredJwtException e) {
+            log.error("JwtTokenProvider: Token expired - {}", e.getMessage()); // 로그 추가
+            throw new Exception("Token expired", e);
+        } catch (io.jsonwebtoken.SignatureException e) {
+            log.error("JwtTokenProvider: Invalid JWT signature - {}", e.getMessage()); // 로그 추가
+            throw new Exception("Invalid JWT signature", e);
+        } catch (Exception e) {
+            log.error("JwtTokenProvider: Token validation failed with unexpected error - {}", e.getMessage(), e); // 로그 추가
+            throw e;
+        }
     }
 
-    public TokenUserInfo validateRefreshTokenAndGetTokenUserInfo(String token)
-            throws Exception {
-        Claims claims = Jwts.parserBuilder()
-                .setSigningKey(secretKeyRt)
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
+    public TokenUserInfo validateRefreshTokenAndGetTokenUserInfo(String token) throws Exception {
+        log.info("JwtTokenProvider: Validating refresh token - {}", token); // 로그 추가
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(secretKeyRt)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+            log.info("JwtTokenProvider: Refresh token claims - Subject: {}, Role: {}, EmployeeNo: {}", // 로그 추가
+                    claims.getSubject(), claims.get("role", String.class), claims.get("employeeNo", Long.class));
 
-        return TokenUserInfo.builder()
-                .email(claims.getSubject())
-                .hrRole(claims.get("role", String.class))
-                .employeeNo(claims.get("employeeNo", Long.class))
-                .build();
+            return TokenUserInfo.builder()
+                    .email(claims.getSubject())
+                    .hrRole(claims.get("role", String.class))
+                    .employeeNo(claims.get("employeeNo", Long.class))
+                    .build();
+        } catch (io.jsonwebtoken.ExpiredJwtException e) {
+            log.error("JwtTokenProvider: Refresh token expired - {}", e.getMessage()); // 로그 추가
+            throw new Exception("Refresh token expired", e);
+        } catch (io.jsonwebtoken.SignatureException e) {
+            log.error("JwtTokenProvider: Invalid JWT refresh token signature - {}", e.getMessage()); // 로그 추가
+            throw new Exception("Invalid JWT refresh token signature", e);
+        } catch (Exception e) {
+            log.error("JwtTokenProvider: Refresh token validation failed with unexpected error - {}", e.getMessage(), e); // 로그 추가
+            throw e;
+        }
     }
 }
-
-
-
 
 
 

--- a/vacation-service/src/main/java/com/playdata/vacationservice/common/auth/TokenUserInfo.java
+++ b/vacation-service/src/main/java/com/playdata/vacationservice/common/auth/TokenUserInfo.java
@@ -1,6 +1,12 @@
 package com.playdata.vacationservice.common.auth;
 
 import lombok.*;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails; // UserDetails 임포트
+
+import java.util.Collection;
+import java.util.Collections;
 
 @Setter
 @Getter
@@ -8,11 +14,45 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class TokenUserInfo {
+public class TokenUserInfo implements UserDetails { // UserDetails 인터페이스 구현
 
     private String email;
     private String hrRole;
     private Long employeeNo;
 
+    // UserDetails 인터페이스 구현 메소드
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + hrRole));
+    }
 
+    @Override
+    public String getPassword() {
+        return null; // 비밀번호는 토큰에 포함되지 않으므로 null 반환
+    }
+
+    @Override
+    public String getUsername() {
+        return email; // 사용자 이름으로 email 사용
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
 }

--- a/vacation-service/src/main/java/com/playdata/vacationservice/vacation/controller/VacationController.java
+++ b/vacation-service/src/main/java/com/playdata/vacationservice/vacation/controller/VacationController.java
@@ -2,7 +2,9 @@ package com.playdata.vacationservice.vacation.controller;
 
 import com.playdata.vacationservice.common.auth.TokenUserInfo;
 import com.playdata.vacationservice.vacation.dto.VacationRequestDto;
+import com.playdata.vacationservice.vacation.dto.VacationBalanceResDto; // 추가
 import com.playdata.vacationservice.vacation.service.VacationService;
+import com.playdata.vacationservice.common.dto.CommonResDto; // 추가
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
  * 휴가 관련 API 요청을 처리하는 컨트롤러입니다.
  */
 @RestController
-@RequestMapping("/api/v1/vacations")
+@RequestMapping("/vacations")
 @RequiredArgsConstructor
 public class VacationController {
 
@@ -43,5 +45,34 @@ public class VacationController {
     @ExceptionHandler({IllegalStateException.class, IllegalArgumentException.class})
     public ResponseEntity<String> handleVacationException(RuntimeException ex) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    }
+
+    /**
+     * 특정 사용자의 연차 현황을 조회하는 API 엔드포인트입니다.
+     *
+     * @param userInfo 인증된 사용자 정보 (userId 획득용)
+     * @return 연차 현황 정보를 담은 응답 (CommonResDto)
+     */
+    @GetMapping("/balance")
+    public ResponseEntity<CommonResDto<VacationBalanceResDto>> getVacationBalance(@AuthenticationPrincipal TokenUserInfo userInfo) {
+        try {
+            VacationBalanceResDto vacationBalance = vacationService.getVacationBalance(userInfo.getEmployeeNo());
+            return buildSuccessResponse(vacationBalance, "연차 현황 조회 성공");
+        } catch (IllegalArgumentException e) {
+            return buildErrorResponse(HttpStatus.NOT_FOUND, e.getMessage());
+        } catch (Exception e) {
+            return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "연차 현황 조회 중 오류 발생");
+        }
+    }
+
+    // CommonResDto를 위한 헬퍼 메소드
+    private <T> ResponseEntity<CommonResDto<T>> buildSuccessResponse(T data, String message) {
+        CommonResDto<T> resDto = new CommonResDto<>(HttpStatus.OK, message, data);
+        return ResponseEntity.ok(resDto);
+    }
+
+    private <T> ResponseEntity<CommonResDto<T>> buildErrorResponse(HttpStatus status, String message) {
+        CommonResDto<T> resDto = new CommonResDto<>(status, message, null);
+        return ResponseEntity.status(status).body(resDto);
     }
 }

--- a/vacation-service/src/main/java/com/playdata/vacationservice/vacation/dto/VacationBalanceResDto.java
+++ b/vacation-service/src/main/java/com/playdata/vacationservice/vacation/dto/VacationBalanceResDto.java
@@ -1,0 +1,25 @@
+package com.playdata.vacationservice.vacation.dto;
+
+import com.playdata.vacationservice.vacation.entity.VacationBalance;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+public class VacationBalanceResDto {
+    private Long userId;
+    private BigDecimal totalGranted;
+    private BigDecimal usedDays;
+    private BigDecimal remainingDays;
+
+    public static VacationBalanceResDto from(VacationBalance vacationBalance) {
+        return VacationBalanceResDto.builder()
+                .userId(vacationBalance.getUserId())
+                .totalGranted(vacationBalance.getTotalGranted())
+                .usedDays(vacationBalance.getUsedDays())
+                .remainingDays(vacationBalance.getRemainingDays())
+                .build();
+    }
+}

--- a/vacation-service/src/main/java/com/playdata/vacationservice/vacation/service/VacationService.java
+++ b/vacation-service/src/main/java/com/playdata/vacationservice/vacation/service/VacationService.java
@@ -3,6 +3,7 @@ package com.playdata.vacationservice.vacation.service;
 import com.playdata.vacationservice.client.HrServiceClient;
 import com.playdata.vacationservice.common.auth.TokenUserInfo;
 import com.playdata.vacationservice.vacation.dto.VacationRequestDto;
+import com.playdata.vacationservice.vacation.dto.VacationBalanceResDto; // 추가
 import com.playdata.vacationservice.vacation.entity.*;
 import com.playdata.vacationservice.vacation.repository.VacationBalanceRepository;
 import com.playdata.vacationservice.vacation.repository.VacationRepository;
@@ -106,6 +107,21 @@ public class VacationService {
         vacationBalanceRepository.save(vacationBalance);
 
         log.info("사용자 ID: {} 에게 연차 1일이 부여되었습니다. 총 부여된 연차: {}", userId, vacationBalance.getTotalGranted());
+    }
+
+    /**
+     * 특정 사용자의 연차 현황(총 연차, 사용 연차, 남은 연차)을 조회합니다.
+     *
+     * @param userId 연차 현황을 조회할 사용자의 ID
+     * @return 연차 현황 정보를 담은 VacationBalanceResDto
+     * @throws IllegalArgumentException 해당 사용자의 연차 정보를 찾을 수 없는 경우
+     */
+    @Transactional(readOnly = true)
+    public VacationBalanceResDto getVacationBalance(Long userId) {
+        VacationBalance vacationBalance = vacationBalanceRepository.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 사용자의 연차 정보를 찾을 수 없습니다. (User ID: " + userId + ")"));
+
+        return VacationBalanceResDto.from(vacationBalance);
     }
 
     // --- Private Helper Methods for SRP ---

--- a/vacation-service/src/test/java/com/playdata/vacationservice/vacation/controller/VacationControllerTest.java
+++ b/vacation-service/src/test/java/com/playdata/vacationservice/vacation/controller/VacationControllerTest.java
@@ -1,0 +1,117 @@
+package com.playdata.vacationservice.vacation.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.playdata.vacationservice.common.auth.TokenUserInfo;
+import com.playdata.vacationservice.vacation.dto.VacationBalanceResDto;
+import com.playdata.vacationservice.vacation.service.VacationService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(value = VacationController.class, useDefaultFilters = false) // Spring Security 필터 체인 비활성화
+class VacationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private VacationService vacationService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("연차 현황 조회 성공 시 200 OK와 연차 정보를 반환해야 한다.")
+    void getVacationBalance_success() throws Exception {
+        // Given
+        Long userId = 1L;
+        UserDetails mockUserDetails = new User(
+                "test@example.com",
+                "password",
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+
+        VacationBalanceResDto mockResponse = VacationBalanceResDto.builder()
+                .userId(userId)
+                .totalGranted(new BigDecimal("15.0"))
+                .usedDays(new BigDecimal("5.0"))
+                .remainingDays(new BigDecimal("10.0"))
+                .build();
+
+        when(vacationService.getVacationBalance(anyLong()))
+                .thenReturn(mockResponse);
+
+        // When & Then
+        mockMvc.perform(get("/api/v1/vacations/balance")
+                        .with(SecurityMockMvcRequestPostProcessors.user(mockUserDetails))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("연차 현황 조회 성공"))
+                .andExpect(jsonPath("$.result.userId").value(userId))
+                .andExpect(jsonPath("$.result.totalGranted").value(15.0))
+                .andExpect(jsonPath("$.result.usedDays").value(5.0))
+                .andExpect(jsonPath("$.result.remainingDays").value(10.0));
+    }
+
+    @Test
+    @DisplayName("연차 현황 조회 시 연차 정보를 찾을 수 없으면 404 Not Found를 반환해야 한다.")
+    void getVacationBalance_notFound() throws Exception {
+        // Given
+        Long userId = 1L;
+        UserDetails mockUserDetails = new User(
+                "test@example.com",
+                "password",
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+        when(vacationService.getVacationBalance(anyLong()))
+                .thenThrow(new IllegalArgumentException("해당 사용자의 연차 정보를 찾을 수 없습니다."));
+
+        // When & Then
+        mockMvc.perform(get("/api/v1/vacations/balance")
+                        .with(SecurityMockMvcRequestPostProcessors.user(mockUserDetails))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value("NOT_FOUND"))
+                .andExpect(jsonPath("$.message").value("해당 사용자의 연차 정보를 찾을 수 없습니다."));
+    }
+
+    @Test
+    @DisplayName("연차 현황 조회 시 내부 서버 오류 발생 시 500 Internal Server Error를 반환해야 한다.")
+    void getVacationBalance_internalServerError() throws Exception {
+        // Given
+        Long userId = 1L;
+        UserDetails mockUserDetails = new User(
+                "test@example.com",
+                "password",
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+        when(vacationService.getVacationBalance(anyLong()))
+                .thenThrow(new RuntimeException("데이터베이스 연결 오류"));
+
+        // When & Then
+        mockMvc.perform(get("/api/v1/vacations/balance")
+                        .with(SecurityMockMvcRequestPostProcessors.user(mockUserDetails))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.status").value("INTERNAL_SERVER_ERROR"))
+                .andExpect(jsonPath("$.message").value("연차 현황 조회 중 오류 발생"));
+    }
+}


### PR DESCRIPTION
  1 ## 기능 개선 및 추가
    2
    3 이 Pull Request는 근태 및 연차 관리 시스템의 핵심 기능을
      개선하고 새로운 기능을 추가합니다. 사용자 경험을 향상시키고
      데이터의 정확성을 높이는 데 중점을 두었습니다.
    4
    5 ### 주요 변경 사항
    6
    7 #### 1. `attendance-service` 개선
    8 - **남은 근무 시간 및 근무 시간 계산 로직 정밀화**:
    9   - `AttendanceService`의 `getRemainingWorkTime` 메소드에서
      근무한 시간과 남은 근무 시간 계산 시, 1초라도 있으면 다음
      분으로 올림 처리하도록 로직을 수정했습니다.
   10   - `근무한 시간`과 `남은 근무 시간`의 합이 항상 `8시간`이
      되도록 계산 로직을 일관성 있게 조정하여 시간 불일치 문제를
      해결했습니다.
   11 - **오늘 근태 기록 조회 API 추가**:
   12   - 사용자가 로그인 후 또는 근태 페이지 로드 시 현재
      출근/퇴근/외출/복귀 시간을 프론트엔드에 제공하기 위한
      새로운 API (`GET /attendance/today`)를 추가했습니다.
   13   - `AttendanceService`에 `getTodayAttendance` 메소드를,
      `AttendanceController`에 해당 엔드포인트를 구현했습니다.
   14
   15 #### 2. `vacation-service` 개선
   16 - **특정 사용자의 연차 현황 조회 API 추가**:
   17   - 사용자의 총 연차, 사용 연차, 남은 연차를 조회할 수 있는
      새로운 API (`GET /vacations/balance`)를 추가했습니다.
   18   - `VacationBalanceResDto` DTO를 새로 정의하여 연차 현황
      정보를 구조화했습니다.
   19   - `VacationService`에 `getVacationBalance` 메소드를,
      `VacationController`에 해당 엔드포인트를 구현했습니다.
   20 - **테스트용 더미 연차 데이터 추가**:
   21   - `VacationServiceApplication`의 `CommandLineRunner`를
      수정하여 애플리케이션 시작 시 여러 사용자 ID (1L, 2L, 3L,
      4L, 5L)에게 초기 연차 15일을 자동으로 부여하도록 했습니다.
      이는 테스트 환경에서 데이터 준비를 용이하게 합니다.
   22 - **테스트 코드 추가 및 개선**:
   23   - `VacationServiceTest`에 `getVacationBalance` 메소드에
      대한 단위 테스트를 추가했습니다.
   24   - `VacationControllerTest`에 `getVacationBalance` API에
      대한 컨트롤러 테스트를 추가했습니다. Spring Security
      환경에서의 테스트를 위해 `TokenUserInfo`가 `UserDetails`를
      구현하도록 수정하고,
      `SecurityMockMvcRequestPostProcessors.user()`를 사용하여
      인증 정보를 주입하는 방식을 적용했습니다.
   25 - **인증/보안 관련 디버깅 로그 추가**:
   26   - `JwtAuthFilter` 및 `JwtTokenProvider`에 디버깅을 위한
      상세 로그를 추가했습니다. (문제 해결 후 제거 예정)
   27 - **공통 모듈 `TokenUserInfo` 업데이트**:
   28   - `attendance-service`와 `vacation-service`의
      `common.auth.TokenUserInfo` 클래스가 Spring Security의
      `UserDetails` 인터페이스를 구현하도록 수정하여 인증
      시스템과의 호환성을 높였습니다.
   29
   30 ### 테스트 방법
   31
   32 1.  **각 서비스 빌드 및 실행**:

      cd attendance-service && gradlew.bat clean build bootRun
      cd vacation-service && gradlew.bat clean build bootRun


   1 2.  **API 테스트 (포스트맨 또는 프론트엔드)**:
   2     - **연차 현황 조회**: `GET
     http://localhost:8000/vacation-service/vacations/balance`
     (유효한 JWT 토큰 포함)
   3       - `userId`, `totalGranted`, `usedDays`,
     `remainingDays`가 올바르게 반환되는지 확인합니다.
   4     - **오늘 근태 기록 조회**: `GET
     http://localhost:8000/attendance-service/attendance/today`
     (유효한 JWT 토큰 포함)
   5       - `checkInTime`, `checkOutTime`, `goOutTime`,
     `returnTime`이 올바르게 반환되는지 확인합니다. (기록이
     없으면 `result: null` 반환)
   6     - **남은 근무 시간 조회**: `GET
     http://localhost:8000/attendance-service/attendance/remaining-work-time` (유효한 JWT 토큰 포함)
   7       - 출근 후 시간이 지남에 따라 `workedTime`과
     `remainingTime`이 동시에 1분 단위로 정확하게 변하며, 두
     시간의 합이 8시간이 되는지 확인합니다.

