### PR TITLE
 feat(vacation-service): Add rejectComment to VacationHistoryResDto

### DIFF
--- a/vacation-service/src/main/java/com/playdata/vacationservice/vacation/dto/VacationHistoryResDto.java
+++ b/vacation-service/src/main/java/com/playdata/vacationservice/vacation/dto/VacationHistoryResDto.java
@@ -28,6 +28,7 @@ public class VacationHistoryResDto {
     private final String approverName;
     private final Long approverEmployeeNo;
     private final java.time.LocalDate processedAt;
+    private final String rejectComment; // <-- 이 필드를 추가합니다.
 
     /**
      * Vacation 엔티티를 VacationHistoryResDto로 변환합니다.
@@ -49,6 +50,7 @@ public class VacationHistoryResDto {
                 .vacationStatus(vacation.getVacationStatus())
                 .reason(vacation.getReason())
                 .requestedAt(vacation.getCreatedAt() != null ? vacation.getCreatedAt().toLocalDate() : null)
+                .rejectComment(vacation.getRejectComment()) // <-- 이 라인을 추가합니다.
                 .build();
     }
 
@@ -80,6 +82,7 @@ public class VacationHistoryResDto {
                 .approverEmployeeNo(approverEmployeeNo)
                 .processedAt(processedAt)
                 .applicantDepartment(applicantDepartment)
+                .rejectComment(vacation.getRejectComment()) // <-- 이 라인을 추가합니다.
                 .build();
     }
 }


### PR DESCRIPTION
## 개요
휴가 신청 내역 조회 시 반려 사유를 프론트엔드에 전달하기 위해 `VacationHistoryResDto`에 `rejectComment` 필드를 추가했습니다.

## 변경 사항
- `vacation-service/src/main/java/com/playdata/vacationservice/vacation/dto/VacationHistoryResDto.java` 파일 수정  
  - `rejectComment` (String 타입) 필드 추가  
  - `from` 메서드에서 `Vacation` 엔티티의 `rejectComment` 값을 매핑하도록 수정  

## 영향 범위
- `vacation-service`: `/vacations/my-requests` API 응답 DTO 변경  
- 프론트엔드: 휴가 신청 내역 조회 시 반려 사유(`rejectComment`) 필드 사용 가능  

## 테스트 계획
- 휴가 신청 후 반려 처리  
- `/vacations/my-requests` API 호출하여 응답 DTO에 `rejectComment` 필드가 정상적으로 포함되는지 확인  
